### PR TITLE
Add support for remote packages using pak

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ URL: https://github.com/e-kotov/rdocdump, https://www.ekotov.pro/rdocdump/
 BugReports: https://github.com/e-kotov/rdocdump/issues
 Suggests:
     curl,
+    pak,
     quarto,
     testthat (>= 3.0.0),
     withr

--- a/R/extract_code.R
+++ b/R/extract_code.R
@@ -9,7 +9,7 @@
 #'   \item a full path to a package source directory,
 #'   \item a full path to a package archive file (tar.gz),
 #'   \item a package name not installed (which will then be downloaded from CRAN), or
-#'   \item a remote package specification (e.g., "user/repo", "user/repo@branch", "user/repo/subdir") which will be downloaded using the `pak` package. Note that the `pak` package must be installed for this feature.
+#'   \item a remote package specification (e.g., "user/repo", "user/repo@branch", "user/repo/subdir") which will be downloaded using the `pak` package. Note that the `pak` package is required for this feature.
 #' }
 #' @param file Optional. Save path for the output text file. If set, the function will return the path to the file instead of the combined text. Defaults to `NULL`.
 #' @param include_tests `logical`. If `TRUE`, for non-installed packages, the function will also include R source code from the `tests` directory. Defaults to `FALSE`.

--- a/R/extract_code.R
+++ b/R/extract_code.R
@@ -5,10 +5,11 @@
 #'
 #' @param pkg A `character` string specifying the package. This can be:
 #' \itemize{
-#' \item an installed package name,
-#' \item a full path to a package source directory,
-#' \item a full path to a package archive file (tar.gz), or
-#' \item a package name not installed (which will then be downloaded from CRAN).
+#'   \item an installed package name,
+#'   \item a full path to a package source directory,
+#'   \item a full path to a package archive file (tar.gz),
+#'   \item a package name not installed (which will then be downloaded from CRAN), or
+#'   \item a remote package specification (e.g., "user/repo", "user/repo@branch", "user/repo/subdir") which will be downloaded using the `pak` package. Note that the `pak` package must be installed for this feature.
 #' }
 #' @param file Optional. Save path for the output text file. If set, the function will return the path to the file instead of the combined text. Defaults to `NULL`.
 #' @param include_tests `logical`. If `TRUE`, for non-installed packages, the function will also include R source code from the `tests` directory. Defaults to `FALSE`.

--- a/R/to_txt.R
+++ b/R/to_txt.R
@@ -9,7 +9,7 @@
 #'   \item a full path to a package source directory,
 #'   \item a full path to a package archive file (tar.gz),
 #'   \item a package name not installed (which will then be downloaded from CRAN), or
-#'   \item a remote package specification (e.g., "user/repo", "user/repo@branch", "user/repo/subdir") which will be downloaded using the `pak` package. Note that the `pak` package must be installed for this feature.
+#'   \item a remote package specification (e.g., "user/repo", "user/repo@branch", "user/repo/subdir") which will be downloaded using the `pak` package. Note that the `pak` package is required for this feature.
 #' }
 #' @param file Optional. Save path for the output text file. If set, the function will return the path to the file instead of the combined text. Defaults to `NULL`.
 #' @param force_fetch `logical`. If `TRUE`, the package source will be fetched from CRAN as a tar.gz archive even if the package is already installed locally. Default is `FALSE`, but when `version` is specified, it will be set to `TRUE`.

--- a/R/to_txt.R
+++ b/R/to_txt.R
@@ -7,8 +7,9 @@
 #' \itemize{
 #'   \item an installed package name,
 #'   \item a full path to a package source directory,
-#'   \item a full path to a package archive file (tar.gz), or
-#'   \item a package name not installed (which will then be downloaded from CRAN).
+#'   \item a full path to a package archive file (tar.gz),
+#'   \item a package name not installed (which will then be downloaded from CRAN), or
+#'   \item a remote package specification (e.g., "user/repo", "user/repo@branch", "user/repo/subdir") which will be downloaded using the `pak` package. Note that the `pak` package must be installed for this feature.
 #' }
 #' @param file Optional. Save path for the output text file. If set, the function will return the path to the file instead of the combined text. Defaults to `NULL`.
 #' @param force_fetch `logical`. If `TRUE`, the package source will be fetched from CRAN as a tar.gz archive even if the package is already installed locally. Default is `FALSE`, but when `version` is specified, it will be set to `TRUE`.

--- a/R/util_cleanup_files.R
+++ b/R/util_cleanup_files.R
@@ -26,19 +26,25 @@ cleanup_files <- function(
     }
   }
 
-  if (
-    !keep_files %in% c("extracted", "both") && !is.null(pkg_info$extracted_path)
-  ) {
-    # pkg_info$extracted_path is the directory where the package was extracted.
-    # We should remove this directory, not its parent.
-    dir_to_remove <- pkg_info$extracted_path
-    res <- unlink(dir_to_remove, recursive = TRUE)
-    if (res != 0L) {
-      warning(
-        "cleanup_files: failed to delete extracted directory: ",
-        dir_to_remove,
-        call. = FALSE
-      )
+  if (!keep_files %in% c("extracted", "both")) {
+    # If we have an extracted root, remove it (this includes the pkg_path inside it).
+    if (!is.null(pkg_info$extracted_path)) {
+      dir_to_remove <- pkg_info$extracted_path
+      res <- unlink(dir_to_remove, recursive = TRUE)
+      if (res != 0L) {
+        warning(
+          "cleanup_files: failed to delete extracted directory: ",
+          dir_to_remove,
+          call. = FALSE
+        )
+      }
+    } else if (!is.null(pkg_info$pkg_path) && !isTRUE(pkg_info$is_installed)) {
+      # Fallback: if there is no extracted_path (e.g. source dir), but we are supposed to clean up?
+      # Actually, if is_installed is FALSE and tar_path was NULL, it might be a local source dir provided by user.
+      # resolve_pkg_path sets extracted_path=NULL for existing source dirs.
+      # We generally should NOT delete user-provided source dirs unless we created them.
+      # But resolve_pkg_path sets extracted_path only if it extracted/downloaded something.
+      # So relying on extracted_path is correct.
     }
   }
 

--- a/R/util_cleanup_files.R
+++ b/R/util_cleanup_files.R
@@ -29,7 +29,9 @@ cleanup_files <- function(
   if (
     !keep_files %in% c("extracted", "both") && !is.null(pkg_info$extracted_path)
   ) {
-    dir_to_remove <- dirname(pkg_info$extracted_path)
+    # pkg_info$extracted_path is the directory where the package was extracted.
+    # We should remove this directory, not its parent.
+    dir_to_remove <- pkg_info$extracted_path
     res <- unlink(dir_to_remove, recursive = TRUE)
     if (res != 0L) {
       warning(

--- a/R/util_resolve_pkg_path.R
+++ b/R/util_resolve_pkg_path.R
@@ -46,43 +46,28 @@ resolve_pkg_path <- function(
     }
   }
 
-  # Helper function to flatten extra top-level folder if necessary.
-  flatten_extract_dir <- function(extract_dir) {
-    contents <- list.files(
-      extract_dir,
-      full.names = TRUE,
-      all.files = FALSE, # Ignore hidden files when checking for single dir
-      no.. = TRUE
-    )
-
-    if (length(contents) == 1L && dir.exists(contents)) {
-      subdir <- contents
-      items <- list.files(
-        subdir,
-        full.names = TRUE,
-        all.files = TRUE, # Move everything, including hidden files
-        no.. = TRUE
-      )
-
-      # Attempt to rename, fallback to copy
-      results <- vapply(items, function(x) {
-        dest <- file.path(extract_dir, basename(x))
-        res <- suppressWarnings(file.rename(x, dest))
-        if (!res) {
-          # Fallback to copy and delete
-          res <- file.copy(x, dest, recursive = TRUE, overwrite = TRUE)
-          if (res) unlink(x, recursive = TRUE)
-        }
-        res
-      }, logical(1))
-
-      if (!all(results)) {
-        warning("Failed to move some files during flattening: ",
-                paste(items[!results], collapse = ", "))
-      }
-
-      unlink(subdir, recursive = TRUE)
+  # Helper function to find the package root (containing DESCRIPTION) within an extracted directory.
+  # This avoids the need to move/rename files and robustly handles wrapper directories.
+  find_pkg_root <- function(path) {
+    # Check if the path itself is the root
+    if (file.exists(file.path(path, "DESCRIPTION"))) {
+      return(path)
     }
+
+    # Check immediate subdirectories (to handle wrapper folders like pkgname/ or user-repo-sha/)
+    contents <- list.files(path, full.names = TRUE, all.files = TRUE, no.. = TRUE)
+    dirs <- contents[dir.exists(contents)]
+
+    # If there is exactly one subdirectory, check inside it
+    if (length(dirs) == 1L) {
+      subdir <- dirs[[1]]
+      if (file.exists(file.path(subdir, "DESCRIPTION"))) {
+        return(subdir)
+      }
+    }
+
+    # If not found, return the original path and let downstream functions fail/warn
+    return(path)
   }
 
   if (file.exists(pkg)) {
@@ -124,10 +109,11 @@ resolve_pkg_path <- function(
         dir.create(extract_dir, recursive = TRUE)
       }
       utils::untar(pkg, exdir = extract_dir)
-      flatten_extract_dir(extract_dir)
+
+      pkg_root <- find_pkg_root(extract_dir)
 
       return(list(
-        pkg_path = extract_dir,
+        pkg_path = pkg_root,
         extracted_path = extract_dir,
         tar_path = NULL,
         is_installed = FALSE
@@ -137,7 +123,6 @@ resolve_pkg_path <- function(
     # pkg is not an existing file/directory: treat it as a package name or remote.
 
     # Check if pkg is a remote specification (contains /)
-    # This distinguishes standard CRAN packages (no slash) from GitHub/GitLab remotes (user/repo).
     if (grepl("/", pkg)) {
       if (!requireNamespace("pak", quietly = TRUE)) {
         stop(
@@ -157,7 +142,6 @@ resolve_pkg_path <- function(
         error = function(e) {
           msg <- conditionMessage(e)
           prefix <- "Failed to download package from remote:"
-          # Avoid repeating prefix if already present
           if (grepl(prefix, msg, fixed = TRUE)) {
             stop(msg)
           } else {
@@ -181,10 +165,11 @@ resolve_pkg_path <- function(
         dir.create(extract_dir, recursive = TRUE)
       }
       utils::untar(archive, exdir = extract_dir)
-      flatten_extract_dir(extract_dir)
+
+      pkg_root <- find_pkg_root(extract_dir)
 
       return(list(
-        pkg_path = extract_dir,
+        pkg_path = pkg_root,
         extracted_path = extract_dir,
         tar_path = archive,
         is_installed = FALSE
@@ -293,10 +278,11 @@ resolve_pkg_path <- function(
         dir.create(extract_dir, recursive = TRUE)
       }
       utils::untar(archive, exdir = extract_dir)
-      flatten_extract_dir(extract_dir)
+
+      pkg_root <- find_pkg_root(extract_dir)
 
       return(list(
-        pkg_path = extract_dir,
+        pkg_path = pkg_root,
         extracted_path = extract_dir,
         tar_path = archive,
         is_installed = FALSE

--- a/R/util_resolve_pkg_path.R
+++ b/R/util_resolve_pkg_path.R
@@ -58,6 +58,9 @@ resolve_pkg_path <- function(
     contents <- list.files(path, full.names = TRUE, all.files = TRUE, no.. = TRUE)
     dirs <- contents[dir.exists(contents)]
 
+    # Ignore hidden directories like .git or .github
+    dirs <- dirs[!startsWith(basename(dirs), ".")]
+
     # If there is exactly one subdirectory, check inside it
     if (length(dirs) == 1L) {
       subdir <- dirs[[1]]
@@ -122,15 +125,21 @@ resolve_pkg_path <- function(
   } else {
     # pkg is not an existing file/directory: treat it as a package name or remote.
 
-    # Check if pkg is a remote specification (contains /).
-    # Note: Valid CRAN package names cannot contain slashes.
-    # We exclude strings that look like explicit file paths (start with /, ./, ../, ~)
-    # to avoid treating non-existent local files as remote packages.
-    is_likely_remote <- grepl("/", pkg) &&
-      !grepl("^(/|\\./|\\.\\./|~|\\\\|[a-zA-Z]:)", pkg)
+    # Heuristics to distinguish non-existent local paths from remote specifications.
+    # If it resembles a path (absolute, relative, home, Windows drive, or a path
+    # with separators plus a file extension), treat it as a missing local path
+    # rather than a remote package specification.
+    likely_path_prefix <- grepl("^(/|\\./|\\.\\./|~|\\\\|[A-Za-z]:[/\\\\])", pkg)
+    has_path_sep <- grepl("[/\\\\]", pkg)
+    has_extension <- grepl("\\.[A-Za-z0-9]+$", basename(pkg))
+    is_likely_local_path <- likely_path_prefix || (has_path_sep && has_extension)
+    if (is_likely_local_path) {
+      stop("The specified path does not exist: ", pkg)
+    }
 
-    # Also handle "type::pkg" which might not have slash but has :: (e.g. cran::pkg)
-    if (grepl("::", pkg)) is_likely_remote <- TRUE
+    # Check if pkg is a remote specification (contains /) or uses "type::pkg" syntax.
+    # Note: Valid CRAN package names cannot contain slashes.
+    is_likely_remote <- (grepl("/", pkg) && !likely_path_prefix) || grepl("::", pkg)
 
     if (is_likely_remote) {
       if (!requireNamespace("pak", quietly = TRUE)) {
@@ -140,21 +149,28 @@ resolve_pkg_path <- function(
         )
       }
 
-      message("Fetching package source from remote: ", pkg, " ...")
+      # Handle version parameter if provided
+      pkg_for_download <- pkg
+      if (!is.null(version) && nzchar(version) && !grepl("@", pkg, fixed = TRUE)) {
+        pkg_for_download <- paste0(pkg, "@", version)
+      }
+
+      message("Fetching package source from remote: ", pkg_for_download, " ...")
       dest_dir <- if (!is.null(cache_path)) cache_path else tempdir()
       if (!dir.exists(dest_dir)) {
         dir.create(dest_dir, recursive = TRUE)
       }
 
       dl_info <- tryCatch(
-        pak::pkg_download(pkg, dest_dir = dest_dir, dependencies = FALSE),
+        pak::pkg_download(pkg_for_download, dest_dir = dest_dir, dependencies = FALSE),
         error = function(e) {
           msg <- conditionMessage(e)
           prefix <- "Failed to download package from remote:"
+          # Avoid double prefixing if the message already has it (though pak errors usually don't)
           if (grepl(prefix, msg, fixed = TRUE)) {
             stop(msg)
           } else {
-            stop(prefix, " ", msg)
+            stop(paste(prefix, msg))
           }
         }
       )

--- a/R/util_resolve_pkg_path.R
+++ b/R/util_resolve_pkg_path.R
@@ -46,6 +46,29 @@ resolve_pkg_path <- function(
     }
   }
 
+  # Helper function to flatten extra top-level folder if necessary.
+  flatten_extract_dir <- function(extract_dir) {
+    contents <- list.files(
+      extract_dir,
+      full.names = TRUE,
+      all.files = FALSE,
+      no.. = TRUE
+    )
+    if (length(contents) == 1L && dir.exists(contents)) {
+      subdir <- contents
+      items <- list.files(
+        subdir,
+        full.names = TRUE,
+        all.files = TRUE,
+        no.. = TRUE
+      )
+      sapply(items, function(x) {
+        file.rename(x, file.path(extract_dir, basename(x)))
+      })
+      unlink(subdir, recursive = TRUE)
+    }
+  }
+
   if (file.exists(pkg)) {
     if (dir.exists(pkg)) {
       # Check if directory is a source package by looking for Rd files in "man/"
@@ -85,18 +108,8 @@ resolve_pkg_path <- function(
         dir.create(extract_dir, recursive = TRUE)
       }
       utils::untar(pkg, exdir = extract_dir)
-      # Flatten extra top-level folder if necessary.
-      subdirs <- list.dirs(extract_dir, recursive = FALSE, full.names = TRUE)
-      if (length(subdirs) == 1L) {
-        files <- list.files(
-          subdirs[1],
-          full.names = TRUE,
-          all.files = TRUE,
-          no.. = TRUE
-        )
-        file.copy(files, extract_dir, recursive = TRUE)
-        unlink(subdirs[1], recursive = TRUE)
-      }
+      flatten_extract_dir(extract_dir)
+
       return(list(
         pkg_path = extract_dir,
         extracted_path = extract_dir,
@@ -105,7 +118,53 @@ resolve_pkg_path <- function(
       ))
     }
   } else {
-    # pkg is not an existing file/directory: treat it as a package name.
+    # pkg is not an existing file/directory: treat it as a package name or remote.
+
+    # Check if pkg is a remote specification (contains /)
+    if (grepl("/", pkg)) {
+      if (!requireNamespace("pak", quietly = TRUE)) {
+        stop(
+          "The 'pak' package is required to download packages from remote sources (e.g., GitHub, GitLab).\n",
+          "Please install it using install.packages('pak')."
+        )
+      }
+
+      message("Fetching package source from remote: ", pkg, " ...")
+      dest_dir <- if (!is.null(cache_path)) cache_path else tempdir()
+      if (!dir.exists(dest_dir)) {
+        dir.create(dest_dir, recursive = TRUE)
+      }
+
+      dl_info <- tryCatch(
+        pak::pkg_download(pkg, dest_dir = dest_dir, dependencies = FALSE),
+        error = function(e) stop("Failed to download package from remote: ", e$message)
+      )
+
+      if (nrow(dl_info) < 1) {
+        stop("Failed to download package from remote (no file returned).")
+      }
+
+      archive <- dl_info$fulltarget[1]
+
+      extract_dir <- tryCatch(
+        get_extract_dir(archive),
+        error = function(e) tempfile("pak_extract")
+      )
+
+      if (!dir.exists(extract_dir)) {
+        dir.create(extract_dir, recursive = TRUE)
+      }
+      utils::untar(archive, exdir = extract_dir)
+      flatten_extract_dir(extract_dir)
+
+      return(list(
+        pkg_path = extract_dir,
+        extracted_path = extract_dir,
+        tar_path = archive,
+        is_installed = FALSE
+      ))
+    }
+
     # If force_fetch is TRUE, ignore any locally installed package.
     pkg_found <- if (!force_fetch) {
       tryCatch(find.package(pkg), error = function(e) NULL)
@@ -208,17 +267,8 @@ resolve_pkg_path <- function(
         dir.create(extract_dir, recursive = TRUE)
       }
       utils::untar(archive, exdir = extract_dir)
-      subdirs <- list.dirs(extract_dir, recursive = FALSE, full.names = TRUE)
-      if (length(subdirs) == 1L) {
-        files <- list.files(
-          subdirs[1],
-          full.names = TRUE,
-          all.files = TRUE,
-          no.. = TRUE
-        )
-        file.copy(files, extract_dir, recursive = TRUE)
-        unlink(subdirs[1], recursive = TRUE)
-      }
+      flatten_extract_dir(extract_dir)
+
       return(list(
         pkg_path = extract_dir,
         extracted_path = extract_dir,

--- a/R/util_resolve_pkg_path.R
+++ b/R/util_resolve_pkg_path.R
@@ -51,20 +51,36 @@ resolve_pkg_path <- function(
     contents <- list.files(
       extract_dir,
       full.names = TRUE,
-      all.files = FALSE,
+      all.files = FALSE, # Ignore hidden files when checking for single dir
       no.. = TRUE
     )
+
     if (length(contents) == 1L && dir.exists(contents)) {
       subdir <- contents
       items <- list.files(
         subdir,
         full.names = TRUE,
-        all.files = TRUE,
+        all.files = TRUE, # Move everything, including hidden files
         no.. = TRUE
       )
-      sapply(items, function(x) {
-        file.rename(x, file.path(extract_dir, basename(x)))
-      })
+
+      # Attempt to rename, fallback to copy
+      results <- vapply(items, function(x) {
+        dest <- file.path(extract_dir, basename(x))
+        res <- suppressWarnings(file.rename(x, dest))
+        if (!res) {
+          # Fallback to copy and delete
+          res <- file.copy(x, dest, recursive = TRUE, overwrite = TRUE)
+          if (res) unlink(x, recursive = TRUE)
+        }
+        res
+      }, logical(1))
+
+      if (!all(results)) {
+        warning("Failed to move some files during flattening: ",
+                paste(items[!results], collapse = ", "))
+      }
+
       unlink(subdir, recursive = TRUE)
     }
   }
@@ -121,6 +137,7 @@ resolve_pkg_path <- function(
     # pkg is not an existing file/directory: treat it as a package name or remote.
 
     # Check if pkg is a remote specification (contains /)
+    # This distinguishes standard CRAN packages (no slash) from GitHub/GitLab remotes (user/repo).
     if (grepl("/", pkg)) {
       if (!requireNamespace("pak", quietly = TRUE)) {
         stop(
@@ -137,10 +154,19 @@ resolve_pkg_path <- function(
 
       dl_info <- tryCatch(
         pak::pkg_download(pkg, dest_dir = dest_dir, dependencies = FALSE),
-        error = function(e) stop("Failed to download package from remote: ", e$message)
+        error = function(e) {
+          msg <- conditionMessage(e)
+          prefix <- "Failed to download package from remote:"
+          # Avoid repeating prefix if already present
+          if (grepl(prefix, msg, fixed = TRUE)) {
+            stop(msg)
+          } else {
+            stop(prefix, " ", msg)
+          }
+        }
       )
 
-      if (nrow(dl_info) < 1) {
+      if (is.null(dl_info) || nrow(dl_info) < 1) {
         stop("Failed to download package from remote (no file returned).")
       }
 

--- a/R/util_resolve_pkg_path.R
+++ b/R/util_resolve_pkg_path.R
@@ -58,10 +58,11 @@ resolve_pkg_path <- function(
     contents <- list.files(path, full.names = TRUE, all.files = TRUE, no.. = TRUE)
     dirs <- contents[dir.exists(contents)]
 
-    # Ignore hidden directories like .git or .github
-    dirs <- dirs[!startsWith(basename(dirs), ".")]
-
     # If there is exactly one subdirectory, check inside it
+    dirs <- contents[
+      dir.exists(contents) & !startsWith(basename(contents), ".")
+    ]
+    # If there is exactly one non-hidden subdirectory, check inside it
     if (length(dirs) == 1L) {
       subdir <- dirs[[1]]
       if (file.exists(file.path(subdir, "DESCRIPTION"))) {

--- a/R/util_resolve_pkg_path.R
+++ b/R/util_resolve_pkg_path.R
@@ -122,8 +122,17 @@ resolve_pkg_path <- function(
   } else {
     # pkg is not an existing file/directory: treat it as a package name or remote.
 
-    # Check if pkg is a remote specification (contains /)
-    if (grepl("/", pkg)) {
+    # Check if pkg is a remote specification (contains /).
+    # Note: Valid CRAN package names cannot contain slashes.
+    # We exclude strings that look like explicit file paths (start with /, ./, ../, ~)
+    # to avoid treating non-existent local files as remote packages.
+    is_likely_remote <- grepl("/", pkg) &&
+      !grepl("^(/|\\./|\\.\\./|~|\\\\|[a-zA-Z]:)", pkg)
+
+    # Also handle "type::pkg" which might not have slash but has :: (e.g. cran::pkg)
+    if (grepl("::", pkg)) is_likely_remote <- TRUE
+
+    if (is_likely_remote) {
       if (!requireNamespace("pak", quietly = TRUE)) {
         stop(
           "The 'pak' package is required to download packages from remote sources (e.g., GitHub, GitLab).\n",

--- a/tests/testthat/test-remote_logic.R
+++ b/tests/testthat/test-remote_logic.R
@@ -1,62 +1,98 @@
+test_that("resolve_pkg_path identifies remote packages correctly", {
+  skip_if_not_installed("pak")
 
-test_that("resolve_pkg_path identifies remote package and errors without pak", {
-  # Mocking requireNamespace to return FALSE for "pak"
-  # Since we can't easily mock requireNamespace in testthat without mockery,
-  # we rely on the fact that if pak IS installed, this test will fail to error.
-  # So we check if pak is installed first.
-
-  if (!requireNamespace("pak", quietly = TRUE)) {
-    expect_error(
-      resolve_pkg_path("user/repo"),
-      "The 'pak' package is required"
-    )
-  } else {
-    # If pak IS installed, we can't easily test the error path without mocking.
-    # We can at least test that it tries to download and fails (since "user/repo" is likely invalid)
-    # or skip.
-    skip("pak is installed, skipping 'missing pak' test")
-  }
-})
-
-test_that("resolve_pkg_path works for CRAN packages", {
-  # "stats" is a base package, should be found installed
-  res <- resolve_pkg_path("stats")
-  expect_true(res$is_installed)
-  expect_equal(res$pkg_name, "stats")
-})
-
-test_that("resolve_pkg_path distinguishes local file from remote", {
-  # Create a dummy file with a slash in name (if possible? no, but path has slashes)
-  tmp <- tempfile()
-  dir.create(tmp)
-  # Create a dummy tarball structure
-  tar_name <- "dummy_1.0.tar.gz"
-  tar_path <- file.path(tmp, tar_name)
-  file.create(tar_path)
-
-  # Should identify as local file (even if extraction fails later due to empty file)
-  # Actually resolve_pkg_path attempts to untar immediately if file exists
-  # So we need a valid tarball to avoid error during untar
-
-  # Creating a minimal valid tarball is hard without tar/R.
-  # We will test the failure mode: if file exists, it tries untar.
-  # If file doesn't exist, it goes to remote check.
-
-  non_existent <- file.path(tmp, "non/existent/package")
-
-  # This path contains "/", so if it doesn't exist, it hits the remote block.
-  # If pak is missing, it errors with "pak required".
-  # If pak is present, it errors with "Failed to download" (because invalid repo).
-
-  if (!requireNamespace("pak", quietly = TRUE)) {
-    expect_error(
-      resolve_pkg_path(non_existent),
-      "The 'pak' package is required"
-    )
-  } else {
-    expect_error(
-      resolve_pkg_path(non_existent),
-      "Failed to download package from remote"
+  # Mock pak::pkg_download to avoid actual network calls
+  mock_pkg_download <- function(pkg, dest_dir, dependencies) {
+    # Simulate a successful download
+    tar_file <- file.path(dest_dir, "testpkg_0.1.tar.gz")
+    # Create a dummy tarball
+    dir.create(file.path(dest_dir, "testpkg"), showWarnings = FALSE)
+    writeLines("Package: testpkg\nVersion: 0.1", file.path(dest_dir, "testpkg", "DESCRIPTION"))
+    utils::tar(tar_file, files = "testpkg", tar = "internal", extra_flags = "-C", root = dest_dir)
+    # Return data frame like pak::pkg_download
+    data.frame(
+      fulltarget = tar_file,
+      stringsAsFactors = FALSE
     )
   }
+
+  local_mocked_bindings(
+    pkg_download = mock_pkg_download,
+    .package = "pak"
+  )
+
+  # Test user/repo format
+  res <- resolve_pkg_path("user/repo", cache_path = tempdir())
+  expect_false(res$is_installed)
+  expect_true(!is.null(res$extracted_path))
+
+  # Test type::pkg format
+  res2 <- resolve_pkg_path("gitlab::user/repo", cache_path = tempdir())
+  expect_false(res2$is_installed)
+})
+
+test_that("resolve_pkg_path does NOT treat non-existent local paths as remotes", {
+  # If we pass a path starting with ./ or / that doesn't exist,
+  # it should fall through to the CRAN check (and fail there),
+  # NOT try to use pak.
+
+  # We mock find.package and download.packages to verify they ARE called (or that pak is NOT called)
+
+  calls <- new.env()
+  calls$pak_called <- FALSE
+
+  mock_pkg_download <- function(...) {
+    calls$pak_called <- TRUE
+    data.frame()
+  }
+
+  # Mock download.packages to just return empty to simulate "not found on CRAN"
+  mock_download_packages <- function(...) {
+    matrix(character(0), nrow = 0, ncol = 2)
+  }
+
+  if (requireNamespace("pak", quietly = TRUE)) {
+    local_mocked_bindings(
+      pkg_download = mock_pkg_download,
+      .package = "pak"
+    )
+  }
+
+  local_mocked_bindings(
+    download.packages = mock_download_packages,
+    .package = "utils"
+  )
+
+  # "./nonexistent" should NOT trigger pak (starts with ./)
+  expect_error(
+    resolve_pkg_path("./nonexistent"),
+    "Package not found on CRAN"
+  )
+  expect_false(calls$pak_called)
+
+  # "nonexistent/path" (no leading ./) SHOULD trigger pak (looks like user/repo)
+  # But fails because our mock returns empty
+  expect_error(
+    resolve_pkg_path("nonexistent/path"),
+    "Failed to download package from remote"
+  )
+  expect_true(calls$pak_called)
+})
+
+test_that("missing pak throws specific error for remote specs", {
+  # Mock requireNamespace to return FALSE for pak
+  mock_requireNamespace <- function(package, ...) {
+    if (package == "pak") return(FALSE)
+    base::requireNamespace(package, ...)
+  }
+
+  local_mocked_bindings(
+    requireNamespace = mock_requireNamespace,
+    .package = "base"
+  )
+
+  expect_error(
+    resolve_pkg_path("user/repo"),
+    "The 'pak' package is required"
+  )
 })

--- a/tests/testthat/test-remote_logic.R
+++ b/tests/testthat/test-remote_logic.R
@@ -11,10 +11,6 @@ test_that("resolve_pkg_path identifies remote packages correctly", {
     writeLines("Package: testpkg\nVersion: 0.1", file.path(pkg_dir, "DESCRIPTION"))
 
     # Use withr::with_dir to change directory safely for tar
-    # Note: we should not rely on 'tar' from utils being mocked if we call it via namespace in the code,
-    # but here we are in the test setup.
-    # The actual code calls utils::untar, not utils::tar.
-
     old_wd <- getwd()
     on.exit(setwd(old_wd))
     setwd(dest_dir)
@@ -47,8 +43,6 @@ test_that("resolve_pkg_path does NOT treat non-existent local paths as remotes",
   # it should fall through to the CRAN check (and fail there),
   # NOT try to use pak.
 
-  # We mock find.package and download.packages to verify they ARE called (or that pak is NOT called)
-
   calls <- new.env()
   calls$pak_called <- FALSE
 
@@ -74,15 +68,25 @@ test_that("resolve_pkg_path does NOT treat non-existent local paths as remotes",
     .package = "utils"
   )
 
-  # "./nonexistent" should NOT trigger pak (starts with ./)
+  # 1. Explicit relative path "./nonexistent"
+  # Should NOT trigger pak (starts with ./)
   expect_error(
     resolve_pkg_path("./nonexistent"),
     "Package not found on CRAN"
   )
   expect_false(calls$pak_called)
 
-  # "nonexistent/path" (no leading ./) SHOULD trigger pak (looks like user/repo)
-  # But fails because our mock returns empty
+  # 2. Absolute path "/tmp/nonexistent" (Unix-style)
+  # Should NOT trigger pak (starts with /)
+  expect_error(
+    resolve_pkg_path("/tmp/nonexistent"),
+    "Package not found on CRAN"
+  )
+  expect_false(calls$pak_called)
+
+  # 3. Remote-like string "nonexistent/path" (no leading ./ or /)
+  # SHOULD trigger pak (looks like user/repo)
+  # But fails because our mock returns empty (or download.packages if it falls through? No, it enters the remote block)
   expect_error(
     resolve_pkg_path("nonexistent/path"),
     "Failed to download package from remote"

--- a/tests/testthat/test-remote_logic.R
+++ b/tests/testthat/test-remote_logic.R
@@ -6,9 +6,16 @@ test_that("resolve_pkg_path identifies remote packages correctly", {
     # Simulate a successful download
     tar_file <- file.path(dest_dir, "testpkg_0.1.tar.gz")
     # Create a dummy tarball
-    dir.create(file.path(dest_dir, "testpkg"), showWarnings = FALSE)
-    writeLines("Package: testpkg\nVersion: 0.1", file.path(dest_dir, "testpkg", "DESCRIPTION"))
-    utils::tar(tar_file, files = "testpkg", tar = "internal", extra_flags = "-C", root = dest_dir)
+    pkg_dir <- file.path(dest_dir, "testpkg")
+    dir.create(pkg_dir, showWarnings = FALSE)
+    writeLines("Package: testpkg\nVersion: 0.1", file.path(pkg_dir, "DESCRIPTION"))
+
+    # Use withr::with_dir to change directory safely for tar
+    old_wd <- getwd()
+    on.exit(setwd(old_wd))
+    setwd(dest_dir)
+    utils::tar("testpkg_0.1.tar.gz", files = "testpkg", tar = "internal")
+
     # Return data frame like pak::pkg_download
     data.frame(
       fulltarget = tar_file,

--- a/tests/testthat/test-remote_logic.R
+++ b/tests/testthat/test-remote_logic.R
@@ -1,0 +1,62 @@
+
+test_that("resolve_pkg_path identifies remote package and errors without pak", {
+  # Mocking requireNamespace to return FALSE for "pak"
+  # Since we can't easily mock requireNamespace in testthat without mockery,
+  # we rely on the fact that if pak IS installed, this test will fail to error.
+  # So we check if pak is installed first.
+
+  if (!requireNamespace("pak", quietly = TRUE)) {
+    expect_error(
+      resolve_pkg_path("user/repo"),
+      "The 'pak' package is required"
+    )
+  } else {
+    # If pak IS installed, we can't easily test the error path without mocking.
+    # We can at least test that it tries to download and fails (since "user/repo" is likely invalid)
+    # or skip.
+    skip("pak is installed, skipping 'missing pak' test")
+  }
+})
+
+test_that("resolve_pkg_path works for CRAN packages", {
+  # "stats" is a base package, should be found installed
+  res <- resolve_pkg_path("stats")
+  expect_true(res$is_installed)
+  expect_equal(res$pkg_name, "stats")
+})
+
+test_that("resolve_pkg_path distinguishes local file from remote", {
+  # Create a dummy file with a slash in name (if possible? no, but path has slashes)
+  tmp <- tempfile()
+  dir.create(tmp)
+  # Create a dummy tarball structure
+  tar_name <- "dummy_1.0.tar.gz"
+  tar_path <- file.path(tmp, tar_name)
+  file.create(tar_path)
+
+  # Should identify as local file (even if extraction fails later due to empty file)
+  # Actually resolve_pkg_path attempts to untar immediately if file exists
+  # So we need a valid tarball to avoid error during untar
+
+  # Creating a minimal valid tarball is hard without tar/R.
+  # We will test the failure mode: if file exists, it tries untar.
+  # If file doesn't exist, it goes to remote check.
+
+  non_existent <- file.path(tmp, "non/existent/package")
+
+  # This path contains "/", so if it doesn't exist, it hits the remote block.
+  # If pak is missing, it errors with "pak required".
+  # If pak is present, it errors with "Failed to download" (because invalid repo).
+
+  if (!requireNamespace("pak", quietly = TRUE)) {
+    expect_error(
+      resolve_pkg_path(non_existent),
+      "The 'pak' package is required"
+    )
+  } else {
+    expect_error(
+      resolve_pkg_path(non_existent),
+      "Failed to download package from remote"
+    )
+  }
+})

--- a/tests/testthat/test-remote_logic.R
+++ b/tests/testthat/test-remote_logic.R
@@ -11,6 +11,10 @@ test_that("resolve_pkg_path identifies remote packages correctly", {
     writeLines("Package: testpkg\nVersion: 0.1", file.path(pkg_dir, "DESCRIPTION"))
 
     # Use withr::with_dir to change directory safely for tar
+    # Note: we should not rely on 'tar' from utils being mocked if we call it via namespace in the code,
+    # but here we are in the test setup.
+    # The actual code calls utils::untar, not utils::tar.
+
     old_wd <- getwd()
     on.exit(setwd(old_wd))
     setwd(dest_dir)

--- a/tests/testthat/test-remote_logic.R
+++ b/tests/testthat/test-remote_logic.R
@@ -36,12 +36,17 @@ test_that("resolve_pkg_path identifies remote packages correctly", {
   # Test type::pkg format
   res2 <- resolve_pkg_path("gitlab::user/repo", cache_path = tempdir())
   expect_false(res2$is_installed)
+
+  # Test user/repo@version format
+  res3 <- resolve_pkg_path("user/repo", version = "v1.0", cache_path = tempdir())
+  expect_false(res3$is_installed)
+  # Mock doesn't validate the pkg string content, but we ensure it didn't crash
 })
 
-test_that("resolve_pkg_path does NOT treat non-existent local paths as remotes", {
+test_that("resolve_pkg_path fails informatively for missing local paths", {
   # If we pass a path starting with ./ or / that doesn't exist,
-  # it should fall through to the CRAN check (and fail there),
-  # NOT try to use pak.
+  # it should FAIL with a specific "path does not exist" error,
+  # NOT try to download it as a remote.
 
   calls <- new.env()
   calls$pak_called <- FALSE
@@ -69,24 +74,32 @@ test_that("resolve_pkg_path does NOT treat non-existent local paths as remotes",
   )
 
   # 1. Explicit relative path "./nonexistent"
-  # Should NOT trigger pak (starts with ./)
+  # Should FAIL immediately as path not found, NOT trigger pak logic
   expect_error(
     resolve_pkg_path("./nonexistent"),
-    "Package not found on CRAN"
+    "specified path does not exist"
   )
   expect_false(calls$pak_called)
 
-  # 2. Absolute path "/tmp/nonexistent" (Unix-style)
-  # Should NOT trigger pak (starts with /)
+  # 2. Absolute path "/tmp/nonexistent" (Unix-style) or Windows absolute
+  # Should FAIL immediately
   expect_error(
     resolve_pkg_path("/tmp/nonexistent"),
-    "Package not found on CRAN"
+    "specified path does not exist"
   )
   expect_false(calls$pak_called)
 
-  # 3. Remote-like string "nonexistent/path" (no leading ./ or /)
+  # 3. Path with extension "foo/bar.tar.gz"
+  # Should FAIL immediately if it looks like a file path
+  expect_error(
+    resolve_pkg_path("nonexistent/package.tar.gz"),
+    "specified path does not exist"
+  )
+  expect_false(calls$pak_called)
+
+  # 4. Remote-like string "nonexistent/path" (no leading ./ or /, no ext)
   # SHOULD trigger pak (looks like user/repo)
-  # But fails because our mock returns empty (or download.packages if it falls through? No, it enters the remote block)
+  # But fails because our mock returns empty (or enters pak block and mock doesn't return valid)
   expect_error(
     resolve_pkg_path("nonexistent/path"),
     "Failed to download package from remote"

--- a/tests/testthat/test-to_txt.R
+++ b/tests/testthat/test-to_txt.R
@@ -49,6 +49,9 @@ test_that("rdd_to_txt combines DESCRIPTION, Rd documentation and vignettes", {
   desc_file <- file.path(pkg_dir, "DESCRIPTION")
   writeLines(c("Package: testpkg", "Version: 0.1"), desc_file)
 
+  # Create R directory to avoid warning
+  dir.create(file.path(pkg_dir, "R"))
+
   # Create a dummy 'man' directory with an Rd file (for documentation)
   man_dir <- file.path(pkg_dir, "man")
   dir.create(man_dir)
@@ -257,14 +260,22 @@ test_that("rdd_to_txt keeps both tar.gz archive and extracted files when keep_fi
   expect_true(length(tar_files) > 0)
 
   # For the extracted package: resolve_pkg_path creates an extraction directory
-  # as file.path(cache_dir, <pkgname>, <version>). For package "ini", we expect a subdirectory
-  # named "ini" to exist under cache_dir.
-  extracted_dir <- file.path(cache_dir, "ini")
-  expect_true(dir.exists(extracted_dir))
+  # as file.path(cache_dir, <pkgname>, <version>).
+  # This directory itself is the root of extraction.
+  # Inside it, we expect the package directory (e.g. "ini") because archives typically contain a root folder.
 
-  # There should be at least one directory inside the "ini" folder.
-  subdirs <- list.dirs(extracted_dir, recursive = FALSE, full.names = TRUE)
-  expect_true(length(subdirs) > 0)
+  # Note: rdd_to_txt calls resolve_pkg_path which returns pkg_path.
+  # But we don't have access to the returned pkg_path here directly.
+  # We know the logic uses cache_dir/ini/ver.
+
+  # Check if we can find the extracted structure.
+  extracted_base <- list.files(cache_dir, full.names = TRUE, pattern = "ini")
+  expect_true(length(extracted_base) > 0)
+
+  # Check inside for files.
+  files_in_cache <- list.files(cache_dir, recursive = TRUE)
+  # Should contain DESCRIPTION somewhere
+  expect_true(any(grepl("DESCRIPTION", files_in_cache)))
 
   # Clean up the cache directory.
   unlink(cache_dir, recursive = TRUE)
@@ -297,11 +308,20 @@ test_that("rdd_to_txt fetches a specific package version when 'version' is provi
   options(repos = old_repos)
 
   # Check that the extracted directory for the correct version exists.
-  expected_dir <- file.path(cache_dir, pkg_name, pkg_version)
-  expect_true(dir.exists(expected_dir))
+  # resolve_pkg_path creates cache_dir/pkgname/version
+  expected_extract_root <- file.path(cache_dir, pkg_name, pkg_version)
+  expect_true(dir.exists(expected_extract_root))
 
   # Verify the version from the DESCRIPTION file.
-  desc_file <- file.path(expected_dir, "DESCRIPTION")
+  # The DESCRIPTION file might be in expected_extract_root/DESCRIPTION
+  # or expected_extract_root/pkgname/DESCRIPTION depending on the archive structure.
+  # CRAN archives for "ini" usually have "ini/DESCRIPTION".
+
+  desc_file <- file.path(expected_extract_root, "DESCRIPTION")
+  if (!file.exists(desc_file)) {
+    desc_file <- file.path(expected_extract_root, pkg_name, "DESCRIPTION")
+  }
+
   expect_true(file.exists(desc_file))
 
   desc_content <- readLines(desc_file)

--- a/tests/testthat/test-util_resolve_pkg_path.R
+++ b/tests/testthat/test-util_resolve_pkg_path.R
@@ -47,6 +47,7 @@ test_that("resolve_pkg_path handles tar.gz archive file correctly", {
   old_wd <- getwd()
   setwd(dirname(dummy_pkg))
   # Create the archive without extra arguments.
+  # tar will include the directory 'basename(dummy_pkg)' in the archive.
   utils::tar(tarfile = tar_path, files = basename(dummy_pkg), tar = "internal")
   setwd(old_wd)
 
@@ -59,12 +60,26 @@ test_that("resolve_pkg_path handles tar.gz archive file correctly", {
   # With cache_path specified, get_extract_dir() should return a directory path.
   expect_true(is.character(pkg_info$pkg_path))
   expect_true(is.character(pkg_info$extracted_path))
-  expect_equal(pkg_info$pkg_path, pkg_info$extracted_path)
+
+  # The extracted path is the root where tar extracted.
+  # The package path should be the subdirectory containing DESCRIPTION.
+  # Since we created the tarball from basename(dummy_pkg), it wraps content in that dir.
+  expect_true(dir.exists(pkg_info$extracted_path))
+
+  # Verify pkg_path is inside extracted_path
+  expect_true(grepl(pkg_info$extracted_path, pkg_info$pkg_path, fixed = TRUE))
+
+  # Specifically, it should be extracted_path/basename(dummy_pkg)
+  expected_pkg_path <- file.path(pkg_info$extracted_path, basename(dummy_pkg))
+  expect_equal(pkg_info$pkg_path, expected_pkg_path)
+
   expect_true(dir.exists(pkg_info$pkg_path))
+  expect_true(file.exists(file.path(pkg_info$pkg_path, "DESCRIPTION")))
 
   # Clean up.
-  unlink(pkg_info$pkg_path, recursive = TRUE)
+  unlink(pkg_info$extracted_path, recursive = TRUE)
   unlink(tar_path)
+  unlink(dummy_pkg, recursive = TRUE)
 })
 
 
@@ -84,6 +99,8 @@ test_that("resolve_pkg_path fetches package from CRAN", {
 
   expect_true(file.exists(pkg_info$tar_path))
   expect_true(dir.exists(pkg_info$pkg_path))
-  unlink(pkg_info$pkg_path, recursive = TRUE)
+  unlink(pkg_info$pkg_path, recursive = TRUE) # This might leave the wrapper dir if different
+  # Better clean up extracted_path if available
+  if (!is.null(pkg_info$extracted_path)) unlink(pkg_info$extracted_path, recursive = TRUE)
   unlink(pkg_info$tar_path)
 })

--- a/tests/testthat/test-util_resolve_pkg_path.R
+++ b/tests/testthat/test-util_resolve_pkg_path.R
@@ -99,8 +99,12 @@ test_that("resolve_pkg_path fetches package from CRAN", {
 
   expect_true(file.exists(pkg_info$tar_path))
   expect_true(dir.exists(pkg_info$pkg_path))
-  unlink(pkg_info$pkg_path, recursive = TRUE) # This might leave the wrapper dir if different
-  # Better clean up extracted_path if available
-  if (!is.null(pkg_info$extracted_path)) unlink(pkg_info$extracted_path, recursive = TRUE)
+
+  # Clean up using the logic in cleanup_files()
+  if (!is.null(pkg_info$extracted_path)) {
+    unlink(pkg_info$extracted_path, recursive = TRUE)
+  } else {
+    unlink(pkg_info$pkg_path, recursive = TRUE)
+  }
   unlink(pkg_info$tar_path)
 })


### PR DESCRIPTION
This PR adds support for downloading R packages from remote sources such as GitHub and GitLab by leveraging the `pak` package. 

Key changes:
- `pak` is added as a suggested dependency.
- The `resolve_pkg_path` function now detects if the `pkg` argument is a remote specification (e.g., "user/repo").
- If a remote specification is detected, it checks for `pak` and uses it to download the source. If `pak` is not installed, it prompts the user to install it.
- The logic for extracting and flattening package archives has been made more robust to handle different archive structures correctly.
- Documentation for the `pkg` parameter has been updated in `rdd_to_txt` and `rdd_extract_code`.

---
*PR created automatically by Jules for task [17651295214213676734](https://jules.google.com/task/17651295214213676734) started by @e-kotov*